### PR TITLE
Creating a temporary Github Workflow to compile Linux build at push

### DIFF
--- a/.github/workflows/linux-build-release.yaml
+++ b/.github/workflows/linux-build-release.yaml
@@ -34,6 +34,7 @@ jobs:
           cp -p build/decompiler/decompiler Releases/
           cp -p build/decompiler/extractor Releases/
           cp -p build/goalc/goalc Releases/
+          cp -p build/goalc/goalc-simple Releases/
           cp -p build/lsp/lsp Releases/
           cd Releases
           tar cfz archipelagoal_linux.tar.gz gk decompiler extractor goalc lsp

--- a/.github/workflows/linux-build-release.yaml
+++ b/.github/workflows/linux-build-release.yaml
@@ -36,8 +36,14 @@ jobs:
           cp -p build/goalc/goalc Releases/
           cp -p build/goalc/goalc-simple Releases/
           cp -p build/lsp/lsp Releases/
+          mkdir -p Releases/data/decompiler
+          cp -rp goal_src Releases/data/
+          cp -rp custom_levels Releases/data/
+          cp -rp decompiler/config  Releases/data/decompiler
+          cp -rp game Releases/data/
+          cp -rp graphics Releases/data/
           cd Releases
-          tar cfz archipelagoal_linux.tar.gz gk decompiler extractor goalc lsp
+          tar cfz archipelagoal_linux.tar.gz gk decompiler extractor goalc lsp data
           rm gk decompiler extractor goalc lsp
       - name: 'Upload artifact'
         uses: actions/upload-artifact@v4

--- a/.github/workflows/linux-build-release.yaml
+++ b/.github/workflows/linux-build-release.yaml
@@ -29,6 +29,7 @@ jobs:
       - run: |
           cd ${{ github.workspace }}
           mkdir Releases
+          ls
           cp -p game/gk Releases/
           cp -p decompiler/decompiler Releases/
           cp -p decompiler/extractor Releases/

--- a/.github/workflows/linux-build-release.yaml
+++ b/.github/workflows/linux-build-release.yaml
@@ -16,7 +16,7 @@ jobs:
       - run: echo "Checkout done."
       - run: echo "Instaling development package..."
       - run: sudo apt-get update
-      - run: sudo apt-get install build-essential cmake curl g++ nasm clang-format libxrandr-dev libxinerama-dev libxcursor-dev libpulse-dev libxi-dev python3 libgl1-mesa-dev libssl-dev libopenal-dev libogg-dev libvorbis-dev
+      - run: sudo apt-get install build-essential cmake curl g++ nasm clang-format libxrandr-dev libxinerama-dev libxcursor-dev libpulse-dev libxi-dev python3 libgl1-mesa-dev libssl-dev libopenal-dev libogg-dev libvorbis-dev libflac-dev
       - run: echo "Developpement package installed..."
       - run: echo "Compiling..."
       - run: |

--- a/.github/workflows/linux-build-release.yaml
+++ b/.github/workflows/linux-build-release.yaml
@@ -37,11 +37,12 @@ jobs:
           cp -p build/goalc/goalc-simple Releases/
           cp -p build/lsp/lsp Releases/
           mkdir -p Releases/data/decompiler
+          mkdir -p Releases/data/game
           cp -rp goal_src Releases/data/
           cp -rp custom_levels Releases/data/
           cp -rp decompiler/config  Releases/data/decompiler
-          cp -rp game Releases/data/
-          cp -rp graphics Releases/data/
+          cp -rp game/assets Releases/data/game/
+          cp -rp game/graphics Releases/data/game/
           cd Releases
           tar cfz archipelagoal_linux.tar.gz gk decompiler extractor goalc lsp data
           rm gk decompiler extractor goalc lsp

--- a/.github/workflows/linux-build-release.yaml
+++ b/.github/workflows/linux-build-release.yaml
@@ -1,0 +1,45 @@
+# Github Actions script used to build ArchipelaGOAL on Linux
+# LICENSE: MIT
+name: ArchipelaGOAL build
+
+on: [push]
+
+jobs:
+  build-ubuntu:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "The job was automatically triggered by a ${{ github.event_name }} event"
+      - run: echo "Checkout the branch ${{ github.ref }} of the repository ${{ github.repository }}..."
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - run: git submodule update --init
+      - run: echo "Checkout done."
+      - run: echo "Instaling development package..."
+      - run: sudo apt-get update
+      - run: sudo apt-get install build-essential cmake curl g++ nasm clang-format libxrandr-dev libxinerama-dev libxcursor-dev libpulse-dev libxi-dev python libgl1-mesa-dev libssl-dev
+      - run: echo "Developpement package installed..."
+      - run: echo "Compiling..."
+      - run: |
+          mkdir ${{ github.workspace }}/build
+          cd ${{ github.workspace }}/build
+          cmake -DCMAKE_BUILD_TYPE=Release ..
+          make
+      - run: echo "Compiling done."
+      - run: echo "Build standard packaging."
+      - run: |
+          cd ${{ github.workspace }}
+          mkdir Releases
+          cp -p game/gk Releases/
+          cp -p decompiler/decompiler Releases/
+          cp -p decompiler/extractor Releases/
+          cp -p goalc/goalc Releases/
+          cp -p lsp/lsp Releases/
+          cd Releases
+          tar cfz archipelagoal_linux.tar.gz gk decompiler extractor goalc lsp
+          rm gk decompiler extractor goalc lsp
+      - name: 'Upload artifact'
+        uses: actions/upload-artifact@v4
+        with:
+          name: Release-Linux-artefact
+          path: ${{ github.workspace }}/Releases
+          retention-days: 1

--- a/.github/workflows/linux-build-release.yaml
+++ b/.github/workflows/linux-build-release.yaml
@@ -30,11 +30,11 @@ jobs:
           cd ${{ github.workspace }}
           mkdir Releases
           ls
-          cp -p game/gk Releases/
-          cp -p decompiler/decompiler Releases/
-          cp -p decompiler/extractor Releases/
-          cp -p goalc/goalc Releases/
-          cp -p lsp/lsp Releases/
+          cp -p build/game/gk Releases/
+          cp -p build/decompiler/decompiler Releases/
+          cp -p build/decompiler/extractor Releases/
+          cp -p build/goalc/goalc Releases/
+          cp -p build/lsp/lsp Releases/
           cd Releases
           tar cfz archipelagoal_linux.tar.gz gk decompiler extractor goalc lsp
           rm gk decompiler extractor goalc lsp

--- a/.github/workflows/linux-build-release.yaml
+++ b/.github/workflows/linux-build-release.yaml
@@ -16,7 +16,7 @@ jobs:
       - run: echo "Checkout done."
       - run: echo "Instaling development package..."
       - run: sudo apt-get update
-      - run: sudo apt-get install build-essential cmake curl g++ nasm clang-format libxrandr-dev libxinerama-dev libxcursor-dev libpulse-dev libxi-dev python libgl1-mesa-dev libssl-dev
+      - run: sudo apt-get install build-essential cmake curl g++ nasm clang-format libxrandr-dev libxinerama-dev libxcursor-dev libpulse-dev libxi-dev python3 libgl1-mesa-dev libssl-dev
       - run: echo "Developpement package installed..."
       - run: echo "Compiling..."
       - run: |

--- a/.github/workflows/linux-build-release.yaml
+++ b/.github/workflows/linux-build-release.yaml
@@ -16,7 +16,7 @@ jobs:
       - run: echo "Checkout done."
       - run: echo "Instaling development package..."
       - run: sudo apt-get update
-      - run: sudo apt-get install build-essential cmake curl g++ nasm clang-format libxrandr-dev libxinerama-dev libxcursor-dev libpulse-dev libxi-dev python3 libgl1-mesa-dev libssl-dev libopenal-dev
+      - run: sudo apt-get install build-essential cmake curl g++ nasm clang-format libxrandr-dev libxinerama-dev libxcursor-dev libpulse-dev libxi-dev python3 libgl1-mesa-dev libssl-dev libopenal-dev libogg-dev libvorbis-dev
       - run: echo "Developpement package installed..."
       - run: echo "Compiling..."
       - run: |

--- a/.github/workflows/linux-build-release.yaml
+++ b/.github/workflows/linux-build-release.yaml
@@ -16,7 +16,7 @@ jobs:
       - run: echo "Checkout done."
       - run: echo "Instaling development package..."
       - run: sudo apt-get update
-      - run: sudo apt-get install build-essential cmake curl g++ nasm clang-format libxrandr-dev libxinerama-dev libxcursor-dev libpulse-dev libxi-dev python3 libgl1-mesa-dev libssl-dev
+      - run: sudo apt-get install build-essential cmake curl g++ nasm clang-format libxrandr-dev libxinerama-dev libxcursor-dev libpulse-dev libxi-dev python3 libgl1-mesa-dev libssl-dev libopenal-dev
       - run: echo "Developpement package installed..."
       - run: echo "Compiling..."
       - run: |


### PR DESCRIPTION
With this PR, I submit a working Github workflow YAML to compile the GOAL toolkit release for Linux. The YAML generate the release as Artifact that stay accessible for 24 hours. It must then be manually put in the Github Releases section.